### PR TITLE
Add support for prebuilt binaries dependencies

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,6 +18,12 @@ impl std::convert::From<std::path::PathBuf> for BuildDirectory {
     }
 }
 
+impl std::convert::From<&std::path::Path> for BuildDirectory {
+    fn from(f: &std::path::Path) -> Self {
+        Self { 0: f.to_path_buf() }
+    }
+}
+
 impl Default for BuildDirectory {
     fn default() -> Self {
         Self {

--- a/src/external/mod.rs
+++ b/src/external/mod.rs
@@ -39,6 +39,14 @@ pub fn dottie(
                             ds.name, top_pretty_name
                         ));
                     }
+                    DependencySource::FromPrebuilt(ref b) => {
+                        data.push_str(&format!(
+                            "\
+                            {:?} -> {:?}\n\
+                            ",
+                            b.name, top_pretty_name
+                        ));
+                    }
                 }
                 dottie(
                     &requirement.to_build_target(registry).unwrap(),
@@ -48,6 +56,7 @@ pub fn dottie(
                 )?;
             }
         }
+        TargetSource::FromPrebuilt(_) => {}
     }
     Ok(())
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,4 +1,5 @@
 use crate::cache;
+use crate::parser::types;
 use crate::targets;
 use crate::YAMBS_MANIFEST_NAME;
 
@@ -37,109 +38,101 @@ pub struct ManifestData {
     pub targets: Vec<targets::Target>,
 }
 
-#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct RawManifestData {
-    #[serde(rename = "executable")]
-    pub executables: Option<std::collections::HashMap<String, targets::RawExecutableData>>,
-    #[serde(rename = "library")]
-    pub libraries: Option<std::collections::HashMap<String, targets::RawLibraryData>>,
+#[derive(thiserror::Error, Debug)]
+pub enum ParseManifestError {
+    #[error("Failed to parse dependency")]
+    FailedToParseDependency(#[source] targets::DependencyError),
+    #[error("Failed to canonicalize path")]
+    FailedToCanonicalizePath(#[source] std::io::Error),
 }
 
 impl ManifestData {
-    pub fn from_raw(contents: RawManifestData, manifest_dir: &std::path::Path) -> Self {
+    pub fn from_raw(
+        contents: types::RawManifestData,
+        manifest_dir: &std::path::Path,
+    ) -> Result<Self, ParseManifestError> {
         let mut targets = Vec::<targets::Target>::new();
         let mut executables = {
+            let mut target_executables = Vec::new();
             if let Some(executables) = contents.executables {
-                executables
-                    .into_iter()
-                    .map(|(name, data)| {
-                        let dependencies = data
-                            .common_raw
-                            .dependencies
-                            .iter()
-                            .map(|(name, data)| {
-                                let dependency = targets::Dependency::new(name, data, manifest_dir);
-                                match dependency.data {
-                                    targets::DependencyData::Source {
-                                        ref path,
-                                        ref origin,
-                                    } => {
-                                        log::debug!(
-                                            "Found dependency {} in path {} with origin {:?}",
-                                            dependency.name,
-                                            path.display(),
-                                            origin
-                                        );
-                                    }
-                                }
-                                dependency
-                            })
-                            .collect::<Vec<targets::Dependency>>();
-                        targets::Target::Executable(targets::Executable {
-                            name,
-                            sources: data
-                                .common_raw
-                                .sources
-                                .iter()
-                                .map(|source| crate::canonicalize_source(manifest_dir, source))
-                                .collect::<Vec<std::path::PathBuf>>(),
-                            dependencies,
-                            compiler_flags: data.common_raw.compiler_flags,
-                        })
-                    })
-                    .collect::<Vec<targets::Target>>()
-            } else {
-                Vec::new()
+                for executable in executables {
+                    let name = executable.0;
+                    let data = executable.1;
+
+                    let dependencies = data.common_raw.dependencies;
+                    let mut parsed_dependencies = Vec::new();
+                    for dependency in dependencies {
+                        let dep_name = dependency.0;
+                        let dep_data = dependency.1;
+                        let parsed_dependency =
+                            targets::Dependency::new(&dep_name, &dep_data, manifest_dir)
+                                .map_err(ParseManifestError::FailedToParseDependency)?;
+                        parsed_dependencies.push(parsed_dependency);
+                    }
+                    let canonicalized_sources = {
+                        let mut canonicalized_sources = Vec::new();
+                        let sources = data.common_raw.sources;
+                        for source in sources {
+                            let canonicalized_source =
+                                crate::canonicalize_source(manifest_dir, &source)
+                                    .map_err(ParseManifestError::FailedToCanonicalizePath)?;
+                            canonicalized_sources.push(canonicalized_source);
+                        }
+                        Ok(canonicalized_sources)
+                    }?;
+                    let target_executable = targets::Target::Executable(targets::Executable {
+                        name,
+                        sources: canonicalized_sources,
+                        dependencies: parsed_dependencies,
+                        compiler_flags: data.common_raw.compiler_flags,
+                    });
+                    target_executables.push(target_executable);
+                }
             }
-        };
+            Ok(target_executables)
+        }?;
         let mut libraries = {
+            let mut target_libraries = Vec::new();
             if let Some(libraries) = contents.libraries {
-                libraries
-                    .into_iter()
-                    .map(|(name, data)| {
-                        let dependencies = data
-                            .common_raw
-                            .dependencies
-                            .iter()
-                            .map(|(name, data)| {
-                                let dependency = targets::Dependency::new(name, data, manifest_dir);
-                                match dependency.data {
-                                    targets::DependencyData::Source {
-                                        ref path,
-                                        ref origin,
-                                    } => {
-                                        log::debug!(
-                                            "Found dependency {} in path {} with origin {:?}",
-                                            dependency.name,
-                                            path.display(),
-                                            origin
-                                        );
-                                    }
-                                }
-                                dependency
-                            })
-                            .collect::<Vec<targets::Dependency>>();
-                        targets::Target::Library(targets::Library {
-                            name,
-                            sources: data
-                                .common_raw
-                                .sources
-                                .iter()
-                                .map(|source| crate::canonicalize_source(manifest_dir, source))
-                                .collect::<Vec<std::path::PathBuf>>(),
-                            dependencies,
-                            compiler_flags: data.common_raw.compiler_flags,
-                            lib_type: data.lib_type,
-                        })
-                    })
-                    .collect::<Vec<targets::Target>>()
-            } else {
-                Vec::new()
+                for library in libraries {
+                    let name = library.0;
+                    let data = library.1;
+
+                    let dependencies = data.common_raw.dependencies;
+                    let mut parsed_dependencies = Vec::new();
+                    for dependency in dependencies {
+                        let dep_name = dependency.0;
+                        let dep_data = dependency.1;
+                        let parsed_dependency =
+                            targets::Dependency::new(&dep_name, &dep_data, manifest_dir)
+                                .map_err(ParseManifestError::FailedToParseDependency)?;
+                        parsed_dependencies.push(parsed_dependency);
+                    }
+                    let canonicalized_sources = {
+                        let mut canonicalized_sources = Vec::new();
+                        let sources = data.common_raw.sources;
+                        for source in sources {
+                            let canonicalized_source =
+                                crate::canonicalize_source(manifest_dir, &source)
+                                    .map_err(ParseManifestError::FailedToCanonicalizePath)?;
+                            canonicalized_sources.push(canonicalized_source);
+                        }
+                        Ok(canonicalized_sources)
+                    }?;
+                    let target_library = targets::Target::Library(targets::Library {
+                        name,
+                        sources: canonicalized_sources,
+                        dependencies: parsed_dependencies,
+                        compiler_flags: data.common_raw.compiler_flags,
+                        lib_type: data.lib_type,
+                    });
+                    target_libraries.push(target_library);
+                }
             }
-        };
+            Ok(target_libraries)
+        }?;
         targets.append(&mut executables);
         targets.append(&mut libraries);
-        Self { targets }
+        Ok(Self { targets })
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,6 +1,7 @@
 use crate::manifest;
 
 mod constants;
+pub mod types;
 
 // FIXME: Write tests!
 // FIXME: Vurdere variabel for filstier som settes av yambs for å hjelpe forkortelse av paths.
@@ -28,11 +29,9 @@ fn parse_toml(
     manifest_dir: &std::path::Path,
 ) -> Result<manifest::ManifestData, ParseTomlError> {
     let manifest_contents =
-        toml::from_str::<manifest::RawManifestData>(toml).map_err(ParseTomlError::FailedToParse)?;
-    Ok(manifest::ManifestData::from_raw(
-        manifest_contents,
-        manifest_dir,
-    ))
+        toml::from_str::<types::RawManifestData>(toml).map_err(ParseTomlError::FailedToParse)?;
+    manifest::ManifestData::from_raw(manifest_contents, manifest_dir)
+        .map_err(ParseTomlError::FailedToCreateManifestData)
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -43,6 +42,8 @@ pub enum ParseTomlError {
     FailedToRead(#[source] std::io::Error),
     #[error("Failed to convert UTF-8 bytes to string")]
     FailedToConvertUtf8(#[source] std::string::FromUtf8Error),
+    #[error("Failed to create manifest data")]
+    FailedToCreateManifestData(#[source] manifest::ParseManifestError),
 }
 
 #[cfg(test)]
@@ -50,8 +51,9 @@ mod tests {
 
     use super::*;
     use crate::manifest::ManifestData;
-    use crate::targets::{
-        Dependency, DependencyData, Executable, IncludeSearchType, Library, LibraryType, Target,
+    use crate::targets::{Dependency, Executable, Library, Target};
+    use types::{
+        BinaryData, BinaryPath, DependencyData, IncludeSearchType, LibraryType, SourceData,
     };
 
     struct TestFixture {
@@ -73,8 +75,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
-    fn parse_produces_manifest_with_executables() {
+    fn parse_produces_manifest_with_executable() {
         let fixture = TestFixture::new();
         let manifest_dir = fixture.tempdir.path().to_path_buf();
 
@@ -105,51 +106,9 @@ mod tests {
             };
             assert_eq!(manifest, expected);
         }
-        const TOML_WITH_REQUIRE_RECIPE: &str = r#"
-    [executable.x]
-    sources = ['x.cpp', 'y.cpp', 'z.cpp', 'main.cpp']
-
-    [executable.x.dependencies]
-    SomeProject = { path = "/some/path/SomeProject" }
-    SomeSecondProject = { path = "/some/path/SomeSecondProject" }
-    "#;
-        {
-            let manifest = parse_toml(TOML_WITH_REQUIRE_RECIPE, &manifest_dir).unwrap();
-            let executable = Executable {
-                name: "x".to_string(),
-                sources: vec![
-                    manifest_dir.join(std::path::PathBuf::from("x.cpp")),
-                    manifest_dir.join(std::path::PathBuf::from("y.cpp")),
-                    manifest_dir.join(std::path::PathBuf::from("z.cpp")),
-                    manifest_dir.join(std::path::PathBuf::from("main.cpp")),
-                ],
-                dependencies: vec![
-                    Dependency {
-                        name: "SomeProject".to_string(),
-                        data: DependencyData::Source {
-                            path: std::path::PathBuf::from("/some/path/SomeProject"),
-                            origin: IncludeSearchType::Include,
-                        },
-                    },
-                    Dependency {
-                        name: "SomeSecondProject".to_string(),
-                        data: DependencyData::Source {
-                            path: std::path::PathBuf::from("/some/path/SomeSecondProject"),
-                            origin: IncludeSearchType::Include,
-                        },
-                    },
-                ],
-                compiler_flags: None,
-            };
-            let expected = ManifestData {
-                targets: vec![Target::Executable(executable)],
-            };
-            assert_eq!(manifest, expected);
-        }
     }
 
     #[test]
-    #[ignore]
     fn parse_produces_manifest_with_multiple_executables() {
         let fixture = TestFixture::new();
         let manifest_dir = fixture.tempdir.path().to_path_buf();
@@ -165,10 +124,6 @@ mod tests {
 
     [executable.y]
     sources = ['x.cpp', 'y.cpp', 'z.cpp', 'main.cpp']
-
-    [executable.y.dependencies]
-    SomeProject = { path = "/some/path/to/SomeProject" }
-    SomeSecondProject = { path = "/some/path/to/SomeSecondProject" }
     "#;
         {
             let manifest = parse_toml(input, &manifest_dir).unwrap();
@@ -186,27 +141,12 @@ mod tests {
             let executable_y = Executable {
                 name: "y".to_string(),
                 sources: vec![
-                    std::path::PathBuf::from("x.cpp"),
-                    std::path::PathBuf::from("y.cpp"),
-                    std::path::PathBuf::from("z.cpp"),
-                    std::path::PathBuf::from("main.cpp"),
+                    manifest_dir.join(std::path::PathBuf::from("x.cpp")),
+                    manifest_dir.join(std::path::PathBuf::from("y.cpp")),
+                    manifest_dir.join(std::path::PathBuf::from("z.cpp")),
+                    manifest_dir.join(std::path::PathBuf::from("main.cpp")),
                 ],
-                dependencies: vec![
-                    Dependency {
-                        name: "SomeProject".to_string(),
-                        data: DependencyData::Source {
-                            path: std::path::PathBuf::from("/some/path/to/SomeProject"),
-                            origin: IncludeSearchType::Include,
-                        },
-                    },
-                    Dependency {
-                        name: "SomeSecondProject".to_string(),
-                        data: DependencyData::Source {
-                            path: std::path::PathBuf::from("/some/path/to/SomeSecondProject"),
-                            origin: IncludeSearchType::Include,
-                        },
-                    },
-                ],
+                dependencies: Vec::new(),
                 compiler_flags: None,
             };
             let expected = ManifestData {
@@ -278,6 +218,135 @@ mod tests {
             dep_project_path.display(),
             second_dep_project_path.display()
         );
+
+        let manifest = parse_toml(&toml_with_require_recipe, &manifest_dir).unwrap();
+        let library = Library {
+            name: "MyLibraryData".to_string(),
+            sources: vec![
+                manifest_dir.join(std::path::PathBuf::from("x.cpp")),
+                manifest_dir.join(std::path::PathBuf::from("y.cpp")),
+                manifest_dir.join(std::path::PathBuf::from("z.cpp")),
+                manifest_dir.join(std::path::PathBuf::from("generator.cpp")),
+            ],
+            dependencies: vec![
+                Dependency {
+                    name: "SomeProject".to_string(),
+                    data: DependencyData::Source(SourceData {
+                        path: dep_project_path,
+                        origin: IncludeSearchType::Include,
+                    }),
+                },
+                Dependency {
+                    name: "SomeSecondProject".to_string(),
+                    data: DependencyData::Source(SourceData {
+                        path: second_dep_project_path,
+                        origin: IncludeSearchType::Include,
+                    }),
+                },
+            ],
+            compiler_flags: None,
+            lib_type: LibraryType::default(),
+        };
+        let expected = ManifestData {
+            targets: vec![Target::Library(library)],
+        };
+        assert_eq!(manifest, expected);
+    }
+
+    #[test]
+    fn parse_produces_manifest_with_library_with_prebuilt_dependency() {
+        let fixture = TestFixture::new();
+        let manifest_dir = fixture.tempdir.path().to_path_buf();
+
+        fixture.create_dummy_file(&std::path::PathBuf::from("generator.cpp"));
+        fixture.create_dummy_file(&std::path::PathBuf::from("x.cpp"));
+        fixture.create_dummy_file(&std::path::PathBuf::from("y.cpp"));
+        fixture.create_dummy_file(&std::path::PathBuf::from("z.cpp"));
+
+        let dep_project_path = fixture.create_dummy_file(&std::path::PathBuf::from("SomeProject"));
+        let dep_project_include_dir = dep_project_path.parent().unwrap().join("include");
+        std::fs::create_dir(&dep_project_include_dir).unwrap();
+        let toml_with_require_recipe = format!(
+            r#"
+    [library.MyLibraryData]
+    sources = ['x.cpp', 'y.cpp', 'z.cpp', 'generator.cpp']
+
+    [library.MyLibraryData.dependencies.SomeProject]
+    debug.binary_path = "{}"
+    release.binary_path = "{}"
+    include_directory = "{}"
+    "#,
+            dep_project_path.display(),
+            dep_project_path.display(),
+            dep_project_include_dir.display(),
+        );
+        {
+            let manifest = parse_toml(&toml_with_require_recipe, &manifest_dir).unwrap();
+            let library = Library {
+                name: "MyLibraryData".to_string(),
+                sources: vec![
+                    manifest_dir.join(std::path::PathBuf::from("x.cpp")),
+                    manifest_dir.join(std::path::PathBuf::from("y.cpp")),
+                    manifest_dir.join(std::path::PathBuf::from("z.cpp")),
+                    manifest_dir.join(std::path::PathBuf::from("generator.cpp")),
+                ],
+                dependencies: vec![Dependency {
+                    name: "SomeProject".to_string(),
+                    data: DependencyData::Binary(BinaryData {
+                        debug_path_information: BinaryPath {
+                            path: dep_project_path.clone(),
+                        },
+                        release_path_information: BinaryPath {
+                            path: dep_project_path,
+                        },
+                        include_directory: dep_project_include_dir,
+                        search_type: IncludeSearchType::System,
+                    }),
+                }],
+                compiler_flags: None,
+                lib_type: LibraryType::default(),
+            };
+            let expected = ManifestData {
+                targets: vec![Target::Library(library)],
+            };
+            assert_eq!(manifest, expected);
+        }
+    }
+
+    #[test]
+    fn parse_produces_manifest_with_library_with_prebuilt_dependency_and_source_dependency() {
+        let fixture = TestFixture::new();
+        let manifest_dir = fixture.tempdir.path().to_path_buf();
+
+        fixture.create_dummy_file(&std::path::PathBuf::from("generator.cpp"));
+        fixture.create_dummy_file(&std::path::PathBuf::from("x.cpp"));
+        fixture.create_dummy_file(&std::path::PathBuf::from("y.cpp"));
+        fixture.create_dummy_file(&std::path::PathBuf::from("z.cpp"));
+
+        let dep_project_path = fixture.create_dummy_file(&std::path::PathBuf::from("SomeProject"));
+        let dep_project_include_dir = dep_project_path.parent().unwrap().join("include");
+        std::fs::create_dir(&dep_project_include_dir).unwrap();
+
+        let source_dep_project_path =
+            fixture.create_dummy_file(&std::path::PathBuf::from("SomeSourceProject"));
+        let toml_with_require_recipe = format!(
+            r#"
+    [library.MyLibraryData]
+    sources = ['x.cpp', 'y.cpp', 'z.cpp', 'generator.cpp']
+
+    [library.MyLibraryData.dependencies.SomeSourceProject]
+    path = "{}"
+
+    [library.MyLibraryData.dependencies.SomeProject]
+    debug.binary_path = "{}"
+    release.binary_path = "{}"
+    include_directory = "{}"
+    "#,
+            source_dep_project_path.display(),
+            dep_project_path.display(),
+            dep_project_path.display(),
+            dep_project_include_dir.display(),
+        );
         {
             let manifest = parse_toml(&toml_with_require_recipe, &manifest_dir).unwrap();
             let library = Library {
@@ -291,17 +360,23 @@ mod tests {
                 dependencies: vec![
                     Dependency {
                         name: "SomeProject".to_string(),
-                        data: DependencyData::Source {
-                            path: dep_project_path,
-                            origin: IncludeSearchType::Include,
-                        },
+                        data: DependencyData::Binary(BinaryData {
+                            debug_path_information: BinaryPath {
+                                path: dep_project_path.clone(),
+                            },
+                            release_path_information: BinaryPath {
+                                path: dep_project_path,
+                            },
+                            include_directory: dep_project_include_dir,
+                            search_type: IncludeSearchType::System,
+                        }),
                     },
                     Dependency {
-                        name: "SomeSecondProject".to_string(),
-                        data: DependencyData::Source {
-                            path: second_dep_project_path,
+                        name: "SomeSourceProject".to_string(),
+                        data: DependencyData::Source(SourceData {
+                            path: source_dep_project_path.clone(),
                             origin: IncludeSearchType::Include,
-                        },
+                        }),
                     },
                 ],
                 compiler_flags: None,

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -1,0 +1,98 @@
+use crate::flags::CompilerFlags;
+
+#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RawManifestData {
+    #[serde(rename = "executable")]
+    pub executables: Option<std::collections::BTreeMap<String, RawExecutableData>>,
+    #[serde(rename = "library")]
+    pub libraries: Option<std::collections::BTreeMap<String, RawLibraryData>>,
+}
+
+#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct RawExecutableData {
+    #[serde(flatten)]
+    pub common_raw: RawCommonData,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LibraryType {
+    Static,
+    #[serde(rename = "shared")]
+    Dynamic,
+}
+
+impl Default for LibraryType {
+    fn default() -> Self {
+        LibraryType::Static
+    }
+}
+
+#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
+pub struct RawLibraryData {
+    #[serde(flatten)]
+    pub common_raw: RawCommonData,
+    #[serde(default, rename = "type")]
+    pub lib_type: LibraryType,
+}
+
+#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RawCommonData {
+    pub sources: Vec<std::path::PathBuf>,
+    #[serde(default)]
+    pub dependencies: std::collections::BTreeMap<String, DependencyData>,
+    #[serde(flatten)]
+    pub compiler_flags: Option<CompilerFlags>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+pub struct SourceData {
+    pub path: std::path::PathBuf,
+    #[serde(default)]
+    pub origin: IncludeSearchType,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+pub struct BinaryPath {
+    #[serde(rename = "binary_path")]
+    pub path: std::path::PathBuf,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+pub struct BinaryData {
+    #[serde(rename = "debug")]
+    pub debug_path_information: BinaryPath,
+    #[serde(rename = "release")]
+    pub release_path_information: BinaryPath,
+    pub include_directory: std::path::PathBuf,
+    #[serde(default = "IncludeSearchType::system")]
+    pub search_type: IncludeSearchType,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum DependencyData {
+    Source(SourceData),
+    Binary(BinaryData),
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+pub enum IncludeSearchType {
+    System,
+    Include,
+}
+
+impl IncludeSearchType {
+    fn system() -> IncludeSearchType {
+        IncludeSearchType::System
+    }
+}
+
+impl Default for IncludeSearchType {
+    fn default() -> Self {
+        IncludeSearchType::Include
+    }
+}

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1,4 +1,5 @@
 use crate::flags::CompilerFlags;
+use crate::parser::types;
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
 #[serde(untagged)]
@@ -44,95 +45,122 @@ pub struct Library {
     pub sources: Vec<std::path::PathBuf>,
     pub dependencies: Vec<Dependency>,
     pub compiler_flags: Option<CompilerFlags>,
-    pub lib_type: LibraryType,
+    pub lib_type: types::LibraryType,
 }
 
-#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
-#[serde(transparent)]
-pub struct RawExecutableData {
-    #[serde(flatten)]
-    pub common_raw: RawCommonData,
-}
-
-#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
-pub struct RawLibraryData {
-    #[serde(flatten)]
-    pub common_raw: RawCommonData,
-    #[serde(default, rename = "type")]
-    pub lib_type: LibraryType,
-}
-
-#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct RawCommonData {
-    pub sources: Vec<std::path::PathBuf>,
-    #[serde(default)]
-    pub dependencies: std::collections::HashMap<String, DependencyData>,
-    #[serde(flatten)]
-    pub compiler_flags: Option<CompilerFlags>,
-}
-
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum LibraryType {
-    Static,
-    #[serde(rename = "shared")]
-    Dynamic,
-}
-
-impl Default for LibraryType {
-    fn default() -> Self {
-        LibraryType::Static
-    }
+#[derive(thiserror::Error, Debug)]
+pub enum DependencyError {
+    #[error("Failed to canonicalize path \"{0}\"")]
+    FailedToCanonicalizePath(std::path::PathBuf, #[source] std::io::Error),
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
 pub struct Dependency {
     pub name: String,
     #[serde(flatten)]
-    pub data: DependencyData,
+    pub data: types::DependencyData,
 }
 
 impl Dependency {
-    pub fn new(name: &str, data: &DependencyData, manifest_dir: &std::path::Path) -> Self {
-        let (path, origin) = data.source().unwrap();
-        let canonicalized_data = DependencyData::Source {
-            path: crate::canonicalize_source(manifest_dir, &path),
-            origin,
-        };
-        Self {
+    pub fn new(
+        name: &str,
+        data: &types::DependencyData,
+        manifest_dir: &std::path::Path,
+    ) -> Result<Self, DependencyError> {
+        let dependency: Result<Self, DependencyError>;
+        match data {
+            types::DependencyData::Source(ref source_data) => {
+                log::debug!(
+                    "Found dependency {} in path {} with origin {:?}",
+                    name,
+                    source_data.path.display(),
+                    source_data.origin
+                );
+                dependency = Dependency::from_source(name, source_data, manifest_dir);
+            }
+            types::DependencyData::Binary(ref binary_data) => {
+                log::debug!(
+                    "Found prebuilt dependency {}, with search type {:?}
+                    release configuration: {:?}
+                    debug configuration: {:?}
+                    ",
+                    name,
+                    binary_data.search_type,
+                    binary_data.release_path_information,
+                    binary_data.debug_path_information,
+                );
+                dependency = Dependency::from_binary(name, binary_data, manifest_dir);
+            }
+        }
+        dependency
+    }
+
+    pub fn from_source(
+        name: &str,
+        source_data: &types::SourceData,
+        manifest_dir: &std::path::Path,
+    ) -> Result<Self, DependencyError> {
+        let canonicalized_path = crate::canonicalize_source(manifest_dir, &source_data.path)
+            .map_err(|err| {
+                DependencyError::FailedToCanonicalizePath(source_data.path.clone(), err)
+            })?;
+        let canonicalized_data = types::DependencyData::Source(types::SourceData {
+            path: canonicalized_path,
+            origin: source_data.origin.clone(),
+        });
+        Ok(Self {
             name: name.to_string(),
             data: canonicalized_data,
-        }
+        })
     }
-}
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum DependencyData {
-    Source {
-        path: std::path::PathBuf,
-        #[serde(default)]
-        origin: IncludeSearchType,
-    },
-}
+    pub fn from_binary(
+        name: &str,
+        binary_data: &types::BinaryData,
+        manifest_dir: &std::path::Path,
+    ) -> Result<Self, DependencyError> {
+        let canonicalized_release_information = types::BinaryPath {
+            path: crate::canonicalize_source(
+                manifest_dir,
+                &binary_data.release_path_information.path,
+            )
+            .map_err(|err| {
+                DependencyError::FailedToCanonicalizePath(
+                    binary_data.release_path_information.path.clone(),
+                    err,
+                )
+            })?,
+        };
+        let include_directory = crate::canonicalize_source(
+            manifest_dir,
+            &binary_data.include_directory,
+        )
+        .map_err(|err| {
+            DependencyError::FailedToCanonicalizePath(binary_data.include_directory.clone(), err)
+        })?;
 
-impl DependencyData {
-    pub fn source(&self) -> Option<(std::path::PathBuf, IncludeSearchType)> {
-        match self {
-            DependencyData::Source { path, origin } => Some((path.to_owned(), origin.to_owned())),
-        }
-    }
-}
+        let canonicalized_debug_information = types::BinaryPath {
+            path: crate::canonicalize_source(
+                manifest_dir,
+                &binary_data.debug_path_information.path,
+            )
+            .map_err(|err| {
+                DependencyError::FailedToCanonicalizePath(
+                    binary_data.debug_path_information.path.clone(),
+                    err,
+                )
+            })?,
+        };
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
-pub enum IncludeSearchType {
-    System,
-    Include,
-}
-
-impl Default for IncludeSearchType {
-    fn default() -> Self {
-        IncludeSearchType::Include
+        let canonicalized_data = types::DependencyData::Binary(types::BinaryData {
+            release_path_information: canonicalized_release_information,
+            debug_path_information: canonicalized_debug_information,
+            include_directory,
+            search_type: binary_data.search_type.clone(),
+        });
+        Ok(Self {
+            name: name.to_string(),
+            data: canonicalized_data,
+        })
     }
 }


### PR DESCRIPTION
Dependencies can now be included to a yambs project as prebuilt binaries. 

The client has to specify binaries for debug and release builds.